### PR TITLE
Fix for incorrect meta viewport & missing icons on deploy

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,8 @@ module.exports = function (grunt) {
     // Configurable paths
     var config = {
         app: 'app',
-        dist: 'dist'
+        dist: 'dist',
+        components: 'bower_components'
     };
 
     // Define the configuration for all the tasks
@@ -210,6 +211,18 @@ module.exports = function (grunt) {
                   cwd: '<%= config.app %>/scripts',
                   dest: '<%= config.dist %>/scripts/',
                   src: '{,*/}*.js'
+                },{
+                  expand: true,
+                  dot: true,
+                  cwd: '<%= config.components %>/Font-Awesome/fonts',
+                  dest: '<%= config.dist %>/fonts/',
+                  src: '*'
+                },{
+                  expand: true,
+                  dot: true,
+                  cwd: '<%= config.components %>/lightbox2/img',
+                  dest: '<%= config.dist %>/images/',
+                  src: '*.{png,gif}'
                 }]
             },
             styles: {

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png" href="images/Logo2.png">
     <title>Zain Ibrahim Bawahab</title>
 


### PR DESCRIPTION
This pull request fixes two problems.
1. It's initial-scale, not "initial scale" (dash rather than a space). This will fix that white space on the right side on mobile.
2. It will copy the fonts and images from your plugins into the right places so that your icons will show up when you deploy your site.
